### PR TITLE
Support AWS Secret Manager

### DIFF
--- a/DDBStreamCDC/lambda_policy.json
+++ b/DDBStreamCDC/lambda_policy.json
@@ -8,8 +8,8 @@
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::tinybird-test-dynamodb-export",
-                "arn:aws:s3:::tinybird-test-dynamodb-export/*"
+                "arn:aws:s3:::<your-bucket-name>",
+                "arn:aws:s3:::<your-bucket-name>/*"
             ]
         },
         {
@@ -37,6 +37,13 @@
                 "logs:PutLogEvents"
             ],
             "Resource": "arn:aws:logs:*:*:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": "arn:aws:secretsmanager:*:*:secret:TinybirdAPIKey-*"
         }
     ]
 }

--- a/DDBStreamCDC/readme.md
+++ b/DDBStreamCDC/readme.md
@@ -32,7 +32,7 @@ To create the secret:
 3. Select Other Type of Secret
 4. Set the Key as: `TB_CREATE_DS_TOKEN`
 5. Set the Value as the Token from `create datasource token`which you copied from Tinybird; it is usually a long alphanumeric String starting with `p.`
-6. On the next page, name the Secret something like `TinybirdAPIKey`. Consider using a meaningful prefix here so that you can easily set it in your Access Policy in later steps, something like `TinybirdAPIKey-test` would be fine.
+6. On the next page, name the Secret something like `TinybirdAPIKey-test`. Consider using a meaningful prefix here so that you can easily set it in your Access Policy in later steps, something like `TinybirdAPIKey-` with any suffix would be fine.
 
 ## 1. Setup DynamoDB Table
 1. Your DynamoDB table needs to be configured with both DDBStreams activated to send changes, and point-in-time recovery to allow Snapshots to be created. The utils script contains functions to help you with this.
@@ -75,9 +75,9 @@ In the Lambda configuration, add these environment variables:
 #### Required
 The Lambda requires a Tinybird Token to push the data into your Workspace. It requires the `DATASOURCE:APPEND` and `DATASOURCE:CREATE` scopes. By default the `create datasource token` in Tinybird has these scopes already.
 You have two options:
-* TB_CREATE_DS_TOKEN: Set this environment variable with the Token directly if you wish. This will override the Secret option below if set. We recommend you name it with a standard prefix like `TinybirdAPIKey-` to make it easy to set in your access policy for retrieval.
+* TB_CREATE_DS_TOKEN: Set this environment variable with the Token directly if you wish. This will override the Secret option below if set. 
   **OR**
-* TB_CREATE_DS_TOKEN_SECRET_NAME: The name of a Secret in AWS Secrets Manager which contains the necessary Token. This is the default and preferred behavior.
+* TB_CREATE_DS_TOKEN_SECRET_NAME: The name of a Secret in AWS Secrets Manager which contains the necessary Token. This is the default and preferred behavior. We recommend you name it with a standard prefix like `TinybirdAPIKey-` to make it easy to set in your access policy for retrieval.
 
 #### Optional
 1. TB_DS_PREFIX: The prefix to apply to the DynamoDB table names when creating them in Tinybird, it defaults to `ddb_`

--- a/DDBStreamCDC/readme.md
+++ b/DDBStreamCDC/readme.md
@@ -78,6 +78,7 @@ In the Lambda configuration, add these environment variables:
 The Lambda requires a Tinybird Token to push the data into your Workspace. It requires the `DATASOURCE:APPEND` and `DATASOURCE:CREATE` scopes. By default the `create datasource token` in Tinybird has these scopes already.
 You have two options:
 * TB_CREATE_DS_TOKEN: Set this environment variable with the Token directly if you wish. This will override the Secret option below if set. 
+
   **OR**
 * TB_CREATE_DS_TOKEN_SECRET_NAME: The name of a Secret in AWS Secrets Manager which contains the necessary Token. This is the default and preferred behavior. We recommend you name it with a standard prefix like `TinybirdAPIKey-` to make it easy to set in your access policy for retrieval.
 

--- a/DDBStreamCDC/readme.md
+++ b/DDBStreamCDC/readme.md
@@ -9,6 +9,7 @@ This README outlines the process of setting up a Change Data Capture (CDC) syste
 * You can trigger a DynamoDB Snapshot to (re)initialize the export, and the Streams configuration will keep it up to date.
 * The Tinybird Datasource will automatically index the existing DynamoDB Keys, the rest of each Record will be provided as plain JSON ready for further processing.
 * You can deploy an example Materialized View to query the test data
+* Structure: DynamoDB, IAM (Role and Policy) >> S3, Lambda, Secrets Manager >> Tinybird
 
 ## Limitations
 
@@ -18,6 +19,7 @@ This README outlines the process of setting up a Change Data Capture (CDC) syste
 4. Batch sizes are largely configurable in the Lambda Trigger for the number of DDBStreams events to collect in each Trigger, and the amount of time to wait before invoking if enough events haven't arrived. This should give users good control over latency vs efficiency during the CDC replication stage of the processing.
 5. We do not automatically index DynamoDB GSIs. This is largely because they are not provided in the Stream event, and it would be an expensive operation to fetch the DynamoDB Table Description for them during every Invocation.
 6. The example Materialized View is deliberately simple to aid education, please contact us if you want to discuss more complex or high volume use cases.
+7. We use Lambda Triggers to receive and process data from the DynamoDB Stream feature. As of writing this only works within the same AWS Account and Region.
 
 ## 0. Create a Tinybird Workspace
 1. You will need a Tinybird Workspace to ship the DynamoDB Data to, either an existing one or create a new one.


### PR DESCRIPTION
Add functionality to use AWS Secret Manager for TInybird Token.
Add secret manager to access Policy. 
Update placeholder items. 
Update readme instructions, note changed environment variable names.