### PR TITLE
Fix mainfest-summary.json unavailable and empty export file parsing

### DIFF
--- a/DDBStreamCDC/lambda_function.py
+++ b/DDBStreamCDC/lambda_function.py
@@ -75,7 +75,7 @@ def lambda_handler(event, context):
         # Check Region is set
         if not REGION:
             raise ValueError("AWS Region not set in environment variables")
-        if 'Records' in event:
+        if 'Records' in event and event['Records']:
             if 's3' in event['Records'][0]:
                 logger.debug(f"Processing event type S3: {json.dumps(event)}")
                 s3_conditional_setup()
@@ -84,7 +84,7 @@ def lambda_handler(event, context):
                 logger.debug(f"Processing event type DDBStream: {json.dumps(event)}")
                 process_dynamodb_stream_event(event)
             else:
-                logger.error("Unsupported event type")
+                logger.error("Unsupported event type, Records was empty or did not contain S3 or DynamoDB events")
                 raise ValueError("Unsupported event type")
         return {"statusCode": 200, "body": json.dumps("Processing complete")}
     except Exception as e:

--- a/DDBStreamCDC/lambda_policy.json
+++ b/DDBStreamCDC/lambda_policy.json
@@ -23,11 +23,13 @@
             "Resource": "arn:aws:dynamodb:*:*:table/*/stream/*"
         },
         {
-            "Effect": "Allow",
-            "Action": [
-                "dynamodb:DescribeTable"
-            ],
-            "Resource": "arn:aws:dynamodb:*:*:table/*"
+	    "Effect": "Allow",
+	    "Action": [
+		    "dynamodb:DescribeTable",
+		    "dynamodb:ListExports",
+		    "dynamodb:DescribeExport"
+	    ],
+	    "Resource": "arn:aws:dynamodb:*:*:table/*"
         },
         {
             "Effect": "Allow",

--- a/DDBStreamCDC/utils.py
+++ b/DDBStreamCDC/utils.py
@@ -44,7 +44,7 @@ def get_fake():
 # Table name and structure
 DEFAULT_TABLE_NAME = "PeopleTable"
 DEFAULT_REGION = "eu-west-2"
-DEFAULT_S3_BUCKET = "jim-dynamodb-stream"
+DEFAULT_S3_BUCKET = "tinybird-test-dynamodb-export"
 DEFAULT_S3_PREFIX = "DDBStreamCDC"
 DEFAULT_LAMBDA_ROLE_NAME = "DDBStreamCDC-LambdaRole"
 DEFAULT_LAMBDA_FUNCTION_NAME = "DDBStreamCDC-LambdaFunction"


### PR DESCRIPTION
- Check for empty Records when S3 export created on an empty DDB Table.
- reworked s3 event pathway to fetch export details instead of using manifest, as manifest may take several minutes to complete.
- Added cache update when creating new Tinybird table to save an API call.
- Set utils.py default s3 bucket to a simple default.
- Enforced and logged region usage in boto3 client in lambda.